### PR TITLE
Modify UBS return when error to be empty list

### DIFF
--- a/src/cbc_binary_toolkit/ingestion_component.py
+++ b/src/cbc_binary_toolkit/ingestion_component.py
@@ -113,5 +113,5 @@ class IngestionComponent:
                                                   "INGESTED")
                 fetched_metadata.append(metadata)
 
-        log.info(f"Ingested: {datetime.now()}")
+        log.debug(f"Ingested: {datetime.now()}")
         return fetched_metadata

--- a/src/cbc_binary_toolkit/ubs.py
+++ b/src/cbc_binary_toolkit/ubs.py
@@ -175,7 +175,7 @@ def download_hashes(cbth, hashes, expiration_seconds=3600):
 
     Returns:
         found_hashes (List[Dict]): found hashes and their download URLs.
-        None if an error occurred during download.
+        Empty list if an error occurred during download.
 
     Examples:
         >>> download_hashes(cbth, ["0995f71c34f613207bc39ed4fcc1bbbee396a543fa1739656f7ddf70419309fc"])
@@ -183,7 +183,7 @@ def download_hashes(cbth, hashes, expiration_seconds=3600):
     """
     if not hashes:
         log.error("No hashes supplied to download_hashes.")
-        return
+        return list()
     download = _download_hashes(cbth, hashes, expiration_seconds)
 
     checked_download, retried_download = _validate_download(cbth, download, expiration_seconds)
@@ -195,6 +195,9 @@ def download_hashes(cbth, hashes, expiration_seconds=3600):
         found_hashes = checked_download + retried_download
     else:
         found_hashes = checked_download
+
+    if found_hashes is None:
+        found_hashes = list()
     return found_hashes
 
 

--- a/src/tests/component/test_ubs.py
+++ b/src/tests/component/test_ubs.py
@@ -97,7 +97,7 @@ def test_download_hashes_invalid(cbapi_mock, input):
     """Unit test _download_hashes function with empty input."""
     cbapi_mock.mock_request("POST", "/ubs/v1/orgs/test/file/_download", None)
     found_hashes = download_hashes(cbapi_mock.api, input)
-    assert found_hashes is None
+    assert found_hashes == []
 
 
 @pytest.mark.parametrize("hashes", [


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code).
- [x] Linter has passed locally and any fixes were made for failures.
- [x] A self-review of the code has been done.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes (not tied to bugs/features)
- [ ] Other (please describe):


## What is the ticket or issue number?

CBAPI-1428

## Pull Request Description

Fix error behavior of download hashes to return empty list instead of None as this allows for easier result handling in the ingestion code

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?

Manual and unit/integration tests
