### PR TITLE
coveralls token update due to repo name change

### DIFF
--- a/env.encrypted
+++ b/env.encrypted
@@ -1,2 +1,2 @@
 codeship:v2
-M179BomhCuLd34k19d4ZDivBOgPPuvhtz+jv6+CnTXIrqLyM6+gJE9kDb1XI+22iGbHs1tkqJE1vtQvWCSkjlsaXFAm/jM6pNwbmTlilDojA/F1+STKk9mnkEbeuRzJ8c8c30tPgKg==
+syxgwyyjEE1w+MuEoUTyqbe9npoNpNkMGQOgwERtWg5PM3Gjv+xsBaTyJcY5WjRYB0OW8Jv3Psr5Jpn5yq26fGmFlh8VuFFXagGQYppCAlww8CGoyUSaWvQoxVMqFUp84fa4HGvRBA==


### PR DESCRIPTION
I know I am not following my own template, but this is an update to a token for coveralls.